### PR TITLE
Implement per-character respec

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+[*]
+indent_style = space
+end_of_line = lf
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/index.html
+++ b/index.html
@@ -64,6 +64,12 @@
                         <pre class="file-path">%systemdrive%\users\%username%\AppData\LocalLow\Owlcat Games\Pathfinder Kingmaker\Saved Games</pre>
                     </li>
                     <li>
+                      Select a list of characters to respec:
+                      <ul class="party-list">
+                        <li id="loading" class="loading" style="display: none">loading party list...</li>
+                      </ul>
+                    </li>
+                    <li>
                         <a class="file-download first-download-btn" href="#">Press here to change and download your new save file</a>. Store it in the same folder as the previous one.
                     </li>
                     <li>Start your game and load the save named "Temp Respec". Your character should have a white portrait.</li>

--- a/index.html
+++ b/index.html
@@ -64,10 +64,10 @@
                         <pre class="file-path">%systemdrive%\users\%username%\AppData\LocalLow\Owlcat Games\Pathfinder Kingmaker\Saved Games</pre>
                     </li>
                     <li>
-                      Select a list of characters to respec:
-                      <ul class="party-list">
-                        <li id="loading" class="loading" style="display: none">loading party list...</li>
-                      </ul>
+                        Select a list of characters to respec:
+                        <ul class="party-list">
+                            <li id="loading" class="loading" style="display: none">loading party list...</li>
+                        </ul>
                     </li>
                     <li>
                         <a class="file-download first-download-btn" href="#">Press here to change and download your new save file</a>. Store it in the same folder as the previous one.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "rollup-plugin-commonjs": "^9.1.8",
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-postcss": "^1.6.2",
+    "rollup-plugin-serve": "^0.6.0",
     "rollup-plugin-uglify-es": "0.0.1"
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@ import resolve from "rollup-plugin-node-resolve";
 import uglify from 'rollup-plugin-uglify-es';
 import commonjs from "rollup-plugin-commonjs";
 import postcss from "rollup-plugin-postcss";
+import serve from "rollup-plugin-serve";
 
 export default {
     input: "src/index.js",
@@ -26,5 +27,6 @@ export default {
         }),
         commonjs(),
         uglify(),
+        serve(),
     ],
 };

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,0 +1,19 @@
+//
+
+const characterNames = {
+  "77c11edb92ce0fd408ad96b40fd27121": "Linzi",
+  "5455cd3cd375d7a459ca47ea9ff2de78": "Tartuccio",
+  "54be53f0b35bf3c4592a97ae335fe765": "Valerie",
+  "b3f29faef0a82b941af04f08ceb47fa2": "Amiri",
+  "aab03d0ab5262da498b32daa6a99b507": "Harrim",
+  "32d2801eddf236b499d42e4a7d34de23": "Jaethal",
+  "b090918d7e9010a45b96465de7a104c3": "Regongar",
+  "f9161aa0b3f519c47acbce01f53ee217": "Octavia",
+  "f6c23e93512e1b54dba11560446a9e02": "Tristian",
+  "d5bc1d94cd3e5be4bbc03f3366f67afc": "Ekundayo",
+  "ef4e6551044872b4cb99dff10f707971": "Dog",
+  "3f5777b51d301524c9b912812955ee1e": "Jubilost",
+  "f9417988783876044b76f918f8636455": "Nok-Nok",
+}
+
+export default characterNames;

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,19 +1,19 @@
 //
 
 const characterNames = {
-  "77c11edb92ce0fd408ad96b40fd27121": "Linzi",
-  "5455cd3cd375d7a459ca47ea9ff2de78": "Tartuccio",
-  "54be53f0b35bf3c4592a97ae335fe765": "Valerie",
-  "b3f29faef0a82b941af04f08ceb47fa2": "Amiri",
-  "aab03d0ab5262da498b32daa6a99b507": "Harrim",
-  "32d2801eddf236b499d42e4a7d34de23": "Jaethal",
-  "b090918d7e9010a45b96465de7a104c3": "Regongar",
-  "f9161aa0b3f519c47acbce01f53ee217": "Octavia",
-  "f6c23e93512e1b54dba11560446a9e02": "Tristian",
-  "d5bc1d94cd3e5be4bbc03f3366f67afc": "Ekundayo",
-  "ef4e6551044872b4cb99dff10f707971": "Dog",
-  "3f5777b51d301524c9b912812955ee1e": "Jubilost",
-  "f9417988783876044b76f918f8636455": "Nok-Nok",
+    "77c11edb92ce0fd408ad96b40fd27121": "Linzi",
+    "5455cd3cd375d7a459ca47ea9ff2de78": "Tartuccio",
+    "54be53f0b35bf3c4592a97ae335fe765": "Valerie",
+    "b3f29faef0a82b941af04f08ceb47fa2": "Amiri",
+    "aab03d0ab5262da498b32daa6a99b507": "Harrim",
+    "32d2801eddf236b499d42e4a7d34de23": "Jaethal",
+    "b090918d7e9010a45b96465de7a104c3": "Regongar",
+    "f9161aa0b3f519c47acbce01f53ee217": "Octavia",
+    "f6c23e93512e1b54dba11560446a9e02": "Tristian",
+    "d5bc1d94cd3e5be4bbc03f3366f67afc": "Ekundayo",
+    "ef4e6551044872b4cb99dff10f707971": "Dog",
+    "3f5777b51d301524c9b912812955ee1e": "Jubilost",
+    "f9417988783876044b76f918f8636455": "Nok-Nok",
 }
 
 export default characterNames;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,43 @@
+import _ from "lodash"
+import characterNames from "./consts";
+
+export function getCharacterName(descriptor) {
+  if (descriptor.CustomName.length) {
+    return descriptor.CustomName
+  }
+  return characterNames[descriptor.Blueprint] || descriptor.Blueprint
+}
+
+export function getLoadingEl() {
+  return document.getElementById("loading")
+}
+
+export function showLoadingEl() {
+  const el = getLoadingEl()
+  if (el) {
+    el.style.display = "list-item"
+  }
+}
+
+export function removeLoadingEl() {
+  const loadingEl = getLoadingEl()
+  if (!loadingEl) {
+    return
+  }
+  loadingEl.parentNode.removeChild(loadingEl)
+}
+
+export function injectParty(party) {
+  removeLoadingEl()
+  const wrapper = document.getElementsByClassName("party-list")[0]
+  _.forEach(party, (character, id) => {
+    const className = character.shouldRespec ? "selected" : "";
+    wrapper.innerHTML += `<li id="${id}" class="${className}" onclick="toggleSelection('${id}')">${character.name}</li>`
+  })
+}
+
+export function toggleSelectedElById(id) {
+  const el = document.getElementById(id);
+  const className = window.party[id].shouldRespec ? "selected" : "";
+  el.setAttribute("class", className);
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,42 +2,42 @@ import _ from "lodash"
 import characterNames from "./consts";
 
 export function getCharacterName(descriptor) {
-  if (descriptor.CustomName.length) {
-    return descriptor.CustomName
-  }
-  return characterNames[descriptor.Blueprint] || descriptor.Blueprint
+    if (descriptor.CustomName.length) {
+        return descriptor.CustomName
+    }
+    return characterNames[descriptor.Blueprint] || descriptor.Blueprint
 }
 
 export function getLoadingEl() {
-  return document.getElementById("loading")
+    return document.getElementById("loading")
 }
 
 export function showLoadingEl() {
-  const el = getLoadingEl()
-  if (el) {
-    el.style.display = "list-item"
-  }
+    const el = getLoadingEl()
+    if (el) {
+        el.style.display = "list-item"
+    }
 }
 
 export function removeLoadingEl() {
-  const loadingEl = getLoadingEl()
-  if (!loadingEl) {
-    return
-  }
-  loadingEl.parentNode.removeChild(loadingEl)
+    const loadingEl = getLoadingEl()
+    if (!loadingEl) {
+        return
+    }
+    loadingEl.parentNode.removeChild(loadingEl)
 }
 
 export function injectParty(party) {
-  removeLoadingEl()
-  const wrapper = document.getElementsByClassName("party-list")[0]
-  _.forEach(party, (character, id) => {
-    const className = character.shouldRespec ? "selected" : "";
-    wrapper.innerHTML += `<li id="${id}" class="${className}" onclick="toggleSelection('${id}')">${character.name}</li>`
-  })
+    removeLoadingEl()
+    const wrapper = document.getElementsByClassName("party-list")[0]
+    _.forEach(party, (character, id) => {
+        const className = character.shouldRespec ? "selected" : "";
+        wrapper.innerHTML += `<li id="${id}" class="${className}" onclick="toggleSelection('${id}')">${character.name}</li>`
+    })
 }
 
 export function toggleSelectedElById(id) {
-  const el = document.getElementById(id);
-  const className = window.party[id].shouldRespec ? "selected" : "";
-  el.setAttribute("class", className);
+    const el = document.getElementById(id);
+    const className = window.party[id].shouldRespec ? "selected" : "";
+    el.setAttribute("class", className);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,6 +12,18 @@
     max-width: 55rem;
 }
 
+.selected {
+  color: #006e1b;
+}
+
+.loading {
+  color: #6c6c6c;
+}
+
+ul.party-list > li {
+  cursor: pointer;
+}
+
 .file-input {
     margin-top: -1rem;
     margin-bottom: 1rem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,6 +1483,11 @@ micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
+mime@^1.3.6:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
 minimist@0.0.8:
   version "0.0.8"
   resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
@@ -1551,6 +1556,11 @@ object.omit@^2.0.0:
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
+
+opener@^1.4.3:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
+  integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
 os-homedir@^1.0.1:
   version "1.0.2"
@@ -2178,6 +2188,14 @@ rollup-plugin-postcss@^1.6.2:
     resolve "^1.5.0"
     rollup-pluginutils "^2.0.1"
     style-inject "^0.3.0"
+
+rollup-plugin-serve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-serve/-/rollup-plugin-serve-0.6.0.tgz#5243111999ffde4269434e2af69e4b032b4fdefb"
+  integrity sha512-V/V62bpoPf1meWwrTJ/u1WI/cnDW9n50zPj6hTPh0SHZLmT9i3KOnHPZHA33mabcisgm5Rqvo+aP9A/kh0vnfQ==
+  dependencies:
+    mime "^1.3.6"
+    opener "^1.4.3"
 
 rollup-plugin-uglify-es@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
It reads the first file, and adds selectable list of characters as a next step. I tested it and it worked well. 

Couple of notes for the PR:
- added .editorconfig as it was impossible to keep the style rules without it (we treat our code very differently :D )
- added rollup-plugin-serve to easily test locally
- I did notice you annotated types, but its not enforced by anything. You're using some IDE/editor to enforce types?
- there are some good opportunities for refactor, but I figured people would want working version as soon as possible. 